### PR TITLE
[expressions] Add getValue API to lookup property value

### DIFF
--- a/packages/expressions/src/lib/ast_factory.ts
+++ b/packages/expressions/src/lib/ast_factory.ts
@@ -7,6 +7,7 @@ import * as ast from './ast.js';
 
 export interface AstFactory<E extends ast.Expression> {
   empty(): E;
+  getValue(receiver: Record<string, any>, name: string): any;
   literal(value: ast.LiteralValue): E;
   id(name: string): E;
   unary(operator: string, expression: E): E;
@@ -28,6 +29,10 @@ export interface AstFactory<E extends ast.Expression> {
 export class DefaultAstFactory implements AstFactory<ast.Expression> {
   empty(): ast.Empty {
     return {type: 'Empty'};
+  }
+
+  getValue(receiver: Record<string, any>, name: string) {
+    return receiver?.[name];
   }
 
   // TODO(justinfagnani): just use a JS literal?


### PR DESCRIPTION
This PR extracts logic to get property value into separate API and uses that API to do property access. This enables users to override property access to support non-standard access patterns.

Fixes #12 