### PR TITLE
Use responsive friendly grid layout

### DIFF
--- a/packages/site/site/styles.css
+++ b/packages/site/site/styles.css
@@ -12,10 +12,15 @@
 
 body {
   display: grid;
-  place-content: center;
-  padding: var(--size-7);
-  /* gap: var(--size-7); */
+  --gutter: minmax(var(--size-7), 1fr);
+  grid-template-columns: var(--gutter) [content-start] min(100% - var(--size-7) * 2, var(--size-content-3)) [content-end] var(--gutter);
+  padding-block: var(--size-7);
+  margin: 0;
   background-color: var(--surface-1);
+}
+
+main, footer {
+  grid-column: content;
 }
 
 header {
@@ -92,7 +97,7 @@ h4 {
 pre[class*='language-'] {
   background-color: var(--surface-2);
   margin: auto;
-  min-width: 60ch;
+  min-inline-size: min(100%, 60ch);
   border-radius: var(--radius-3);
 }
 


### PR DESCRIPTION
I noticed that on mobile the content horizontally overflows off both sized the screen in a way that makes it impossible to read the content on the left edge. This is a symptom of using inline centring inside of a grid that has no track sizes — a footgun of CSS grid.

This PR uses a grid with three columns:

- The **first** and **last** columns are the gutters. They replace the inline padding and they centre the content. They have a minimum of `2rem` (`--size-7`), but then equally expand to fill the rest of the available space, effectively centring the content.
- The **middle** column, named `content`, is for the content. Both the `<main>` and `<footer>` elements are assigned to this column. It has a track size with a maximum of 80 characters which I took from the paragraph styles (`--size-content-3`). When 80 characters is greater than 100% of the grid’s inline size minus the gutters, it’ll use that value instead.

I also removed the UA `margin` on the body and adjusted the minimum inline size of the code snippets to avoid overflow.

<details><summary>Before</summary>
<img width="1290" height="2796" alt="A screenshot of the Heximal website on iPhone 14 Pro Max via Chrome. The content is overflowing off both edges of the screen." src="https://github.com/user-attachments/assets/d99c774a-91cc-4f50-937b-a761e7bc89d3" />
</details>

<details><summary>After</summary>
<img width="1290" height="2796" alt="A screenshot of the website with the fixes. The content is now within the screen, fully readable." src="https://github.com/user-attachments/assets/53468b1e-af9b-4481-af62-f8771c6f8fd0" />
</details>